### PR TITLE
Make (parts of) FileIt testable

### DIFF
--- a/FileIt/Common/MultipleFileProcessor.cs
+++ b/FileIt/Common/MultipleFileProcessor.cs
@@ -41,7 +41,7 @@ namespace FileIt.Common
             _singleFileProcessor.Init(path);
             foreach (var file in files)
             {
-                using (var stream = new FileIOStream(file))
+                using (var stream = _singleFileProcessor.CreateStream(file))
                 {
                     _singleFileProcessor.Process(stream, args);
                 }

--- a/FileIt/Common/MultipleFileProcessor.cs
+++ b/FileIt/Common/MultipleFileProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FileIt.Interaces;
+using FlexibleStreamHandling;
 
 namespace FileIt.Common
 {
@@ -40,7 +41,10 @@ namespace FileIt.Common
             _singleFileProcessor.Init(path);
             foreach (var file in files)
             {
-                _singleFileProcessor.Process(file, args);
+                using (var stream = new FileIOStream(file))
+                {
+                    _singleFileProcessor.Process(stream, args);
+                }
             }
         }
     }

--- a/FileIt/Common/MultipleFileProcessor.cs
+++ b/FileIt/Common/MultipleFileProcessor.cs
@@ -32,7 +32,8 @@ namespace FileIt.Common
                 Console.WriteLine(e.Message);
                 return;
             }
-            var path = args[1];
+            var pathProvidor = new PathArgumentProvider(args);
+            var path = pathProvidor.Path;
             var files = _fileExtractor.IsDirectory(path)
                 ? _fileExtractor.ExtractFiles(path)
                 : new[] {path};

--- a/FileIt/Common/MultipleFileProcessor.cs
+++ b/FileIt/Common/MultipleFileProcessor.cs
@@ -38,6 +38,7 @@ namespace FileIt.Common
                 : new[] {path};
             Console.WriteLine($"Input path: {path}");
             Console.WriteLine($"Number of files found: {files.Length}");
+            var osService = new ProductionOsService();
             _singleFileProcessor.Init(path);
             foreach (var file in files)
             {

--- a/FileIt/Common/ProductionOsService.cs
+++ b/FileIt/Common/ProductionOsService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using FileIt.Interfaces;
+
+namespace FileIt.Common
+{
+    class ProductionOsService: IOsService
+    {
+        public string GetFileName(string path)
+        {
+            return Path.GetFileName(path);
+        }
+
+        public void WriteLineToConsole(string str)
+        {
+            Console.WriteLine(str);
+        }
+
+        public void MoveFile(string sourceFileName, string destFileName)
+        {
+            File.Move(sourceFileName, destFileName);
+        }
+    }
+}

--- a/FileIt/Common/SpecificOptionProcessor.cs
+++ b/FileIt/Common/SpecificOptionProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using FileIt.Interaces;
+using FileIt.Interfaces;
 
 namespace FileIt.Common
 {
@@ -12,10 +13,12 @@ namespace FileIt.Common
     public abstract class SpecificOptionProcessor
     {
         protected readonly string[] _args;
+        protected readonly IOsService OsService;
 
-        protected SpecificOptionProcessor(string[] args)
+        protected SpecificOptionProcessor(string[] args, IOsService osService)
         {
             _args = args;
+            OsService = osService;
         }
 
         protected abstract IArgumentChecker ArgumentChecker { get; }

--- a/FileIt/Common/StandardFileExtractor.cs
+++ b/FileIt/Common/StandardFileExtractor.cs
@@ -5,9 +5,9 @@ namespace FileIt.Common
     /// <summary>
     /// Recursively extracts all file names (full path), given a directory.
     /// </summary>
-    public class SimpleFileExtractor : FileExtractor
+    public class StandardFileExtractor : FileExtractor
     {
-        public SimpleFileExtractor(string defaultPattern) : base(defaultPattern)
+        public StandardFileExtractor(string defaultPattern) : base(defaultPattern)
         {
         }
         

--- a/FileIt/FileIt.csproj
+++ b/FileIt/FileIt.csproj
@@ -56,7 +56,7 @@
     <Compile Include="Interfaces\ISingleFileProcessor.cs" />
     <Compile Include="Interfaces\IArgumentChecker.cs" />
     <Compile Include="UserOptions\ChangeCodePage\SingleFileConverter.cs" />
-    <Compile Include="Common\SimpleFileExtractor.cs" />
+    <Compile Include="Common\StandardFileExtractor.cs" />
     <Compile Include="UserOptions\FindReplace\ArgumentChecker.cs" />
     <Compile Include="UserOptions\FindReplace\ArgumentProvider.cs" />
     <Compile Include="UserOptions\FindReplace\FindReplaceInFileName.cs" />

--- a/FileIt/FileIt.csproj
+++ b/FileIt/FileIt.csproj
@@ -48,6 +48,8 @@
   <ItemGroup>
     <Compile Include="Common\ArgumentCheckLibrary.cs" />
     <Compile Include="Common\PathArgumentProvider.cs" />
+    <Compile Include="Common\ProductionOsService.cs" />
+    <Compile Include="Interfaces\IOsService.cs" />
     <Compile Include="UserOptions\ChangeCodePage\CodePageProcessor.cs" />
     <Compile Include="Common\FileExtractor.cs" />
     <Compile Include="Common\MultipleFileProcessor.cs" />

--- a/FileIt/Interfaces/IOsService.cs
+++ b/FileIt/Interfaces/IOsService.cs
@@ -1,0 +1,12 @@
+﻿namespace FileIt.Interfaces
+{
+    /// <summary>
+    /// To be able to replace operating system commands in test environment.
+    /// </summary>
+    public interface IOsService
+    {
+        string GetFileName(string path);
+        void WriteLineToConsole(string str);
+        void MoveFile(string sourceFileName, string destFileName);
+    }
+}

--- a/FileIt/Interfaces/ISingleFileProcessor.cs
+++ b/FileIt/Interfaces/ISingleFileProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FileIt.Interfaces;
 using FlexibleStreamHandling;
 
 namespace FileIt.Interaces

--- a/FileIt/Interfaces/ISingleFileProcessor.cs
+++ b/FileIt/Interfaces/ISingleFileProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FlexibleStreamHandling;
 
 namespace FileIt.Interaces
 {
@@ -7,8 +8,7 @@ namespace FileIt.Interaces
         /// <summary>
         /// This is called within a loop, iterating over all files.
         /// </summary>
-        /// <param name="file"></param>
-        void Process(string file, string[] args);
+        void Process(FlexibleStream stream, string[] args);
 
         void Init(string path);
     }

--- a/FileIt/Interfaces/ISingleFileProcessor.cs
+++ b/FileIt/Interfaces/ISingleFileProcessor.cs
@@ -11,5 +11,7 @@ namespace FileIt.Interaces
         void Process(FlexibleStream stream, string[] args);
 
         void Init(string path);
+
+        FlexibleStream CreateStream(string path);
     }
 }

--- a/FileIt/Program.cs
+++ b/FileIt/Program.cs
@@ -13,6 +13,7 @@ namespace FileIt
         {
             var fncCall = args[0];
             SpecificOptionProcessor specificOptionProcessor = null;
+            var osService = new ProductionOsService();
             switch (fncCall.ToLower())
             {
                 case "help":
@@ -27,16 +28,16 @@ namespace FileIt
                     }
                     break;
                 case "changecodepage":
-                    specificOptionProcessor = new CodePageProcessor(args);
+                    specificOptionProcessor = new CodePageProcessor(args, osService);
                     break;
                 case "findreplace":
-                    specificOptionProcessor = new FindReplaceProcessor(args);
+                    specificOptionProcessor = new FindReplaceProcessor(args, osService);
                     break;
                 case "replaceisnull":
-                    specificOptionProcessor = new ReplaceIsNullProcessor(args);
+                    specificOptionProcessor = new ReplaceIsNullProcessor(args, osService);
                     break;
                 case "sqlscriptmerger":
-                    specificOptionProcessor = new SqlScriptMergerProcessor(args);
+                    specificOptionProcessor = new SqlScriptMergerProcessor(args, osService);
                     break;
                 default:
                     Console.WriteLine("Unknown option");

--- a/FileIt/UserOptions/ChangeCodePage/CodePageProcessor.cs
+++ b/FileIt/UserOptions/ChangeCodePage/CodePageProcessor.cs
@@ -12,6 +12,6 @@ namespace FileIt.UserOptions.ChangeCodePage
 
         protected override IArgumentChecker ArgumentChecker => new SingleArgumentPathChecker();
         protected override ISingleFileProcessor SingleFileProcessor => new SingleFileConverter(OsService);
-        protected override FileExtractor FileExtractor => new SimpleFileExtractor("*.sql");
+        protected override FileExtractor FileExtractor => new StandardFileExtractor("*.sql");
     }
 }

--- a/FileIt/UserOptions/ChangeCodePage/CodePageProcessor.cs
+++ b/FileIt/UserOptions/ChangeCodePage/CodePageProcessor.cs
@@ -1,16 +1,17 @@
 ﻿using FileIt.Common;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 
 namespace FileIt.UserOptions.ChangeCodePage
 {
     public class CodePageProcessor : SpecificOptionProcessor
     {
-        public CodePageProcessor(string[] args) : base(args)
+        public CodePageProcessor(string[] args, IOsService osService) : base(args, osService)
         {
         }
 
         protected override IArgumentChecker ArgumentChecker => new SingleArgumentPathChecker();
-        protected override ISingleFileProcessor SingleFileProcessor => new SingleFileConverter();
+        protected override ISingleFileProcessor SingleFileProcessor => new SingleFileConverter(OsService);
         protected override FileExtractor FileExtractor => new SimpleFileExtractor("*.sql");
     }
 }

--- a/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
+++ b/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
@@ -3,32 +3,27 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using FileIt.Interaces;
+using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.ChangeCodePage
 {
     class SingleFileConverter : ISingleFileProcessor
     {
-        public void Process(string file, string[] args)
+        public void Process(FlexibleStream stream, string[] args)
         {
-            Console.WriteLine("Input file: {0}", file);
+            Console.WriteLine("Input file: {0}", stream.GetFileName());
             List<string> lines = new List<string>();
-            using (StreamReader sr = new StreamReader(file))
+            var sr = stream.GetReader();
+            while (!sr.EndOfStream)
             {
-                while (!sr.EndOfStream)
-                {
-                    var line = sr.ReadLine();
-                    lines.Add(line);
-                }
+                var line = sr.ReadLine();
+                lines.Add(line);
             }
-            using (var sw = new StreamWriter(file, false, Encoding.GetEncoding(1252)))
+            foreach (var line in lines)
             {
-                foreach (var line in lines)
-                {
-                    sw.WriteLine(line);
-                }
+                stream.WriteLine(line);
             }
             Console.WriteLine("...Converted");
-
         }
 
         public void Init(string path)

--- a/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
+++ b/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
@@ -3,15 +3,23 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.ChangeCodePage
 {
     class SingleFileConverter : ISingleFileProcessor
     {
+        private readonly IOsService _osService;
+
+        public SingleFileConverter(IOsService osService)
+        {
+            _osService = osService;
+        }
+
         public void Process(FlexibleStream stream, string[] args)
         {
-            Console.WriteLine("Input file: {0}", stream.GetFileName());
+            _osService.WriteLineToConsole($"Input file: {stream.GetFileName()}");
             List<string> lines = new List<string>();
             var sr = stream.GetReader();
             while (!sr.EndOfStream)
@@ -23,7 +31,7 @@ namespace FileIt.UserOptions.ChangeCodePage
             {
                 stream.WriteLine(line);
             }
-            Console.WriteLine("...Converted");
+            _osService.WriteLineToConsole("...Converted");
         }
 
         public void Init(string path)

--- a/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
+++ b/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
@@ -33,5 +33,10 @@ namespace FileIt.UserOptions.ChangeCodePage
         public void Dispose()
         {
         }
+
+        public FlexibleStream CreateStream(string path)
+        {
+            return new FileIOStream(path);
+        }
     }
 }

--- a/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
+++ b/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using FileIt.Interaces;
+using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.FindReplace
 {
@@ -10,14 +11,14 @@ namespace FileIt.UserOptions.FindReplace
         {
         }
 
-        public void Process(string file, string[] args)
+        public void Process(FlexibleStream stream, string[] args)
         {
             var argProvider = new ArgumentProvider(args);
-            var fileName = Path.GetFileName(file);
+            var fileName = Path.GetFileName(stream.GetFileName());
             var newFileName = fileName.Replace(argProvider.FindWhat, argProvider.ReplaceWith);
             Console.WriteLine($"{fileName} --> {newFileName}");
-            var newFilePath = file.Replace(fileName, newFileName);
-            File.Move(file, newFilePath);
+            var newFilePath = stream.GetFileName().Replace(fileName, newFileName);
+            File.Move(stream.GetFileName(), newFilePath);
         }
 
         public void Init(string path)

--- a/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
+++ b/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using FileIt.Interaces;
 using FileIt.Interfaces;
 using FlexibleStreamHandling;
@@ -23,7 +24,9 @@ namespace FileIt.UserOptions.FindReplace
         {
             var argProvider = new ArgumentProvider(args);
             var fileName = _osService.GetFileName(stream.GetFileName());
-            var newFileName = fileName.Replace(argProvider.FindWhat, argProvider.ReplaceWith);
+            var newFileName = Regex.Replace(fileName, argProvider.FindWhat, argProvider.ReplaceWith, 
+                RegexOptions.IgnoreCase);
+            if (newFileName == fileName) return;
             _osService.WriteLineToConsole($"{fileName} --> {newFileName}");
             var newFilePath = stream.GetFileName().Replace(fileName, newFileName);
             _osService.MoveFile(stream.GetFileName(), newFilePath);

--- a/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
+++ b/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
@@ -24,5 +24,10 @@ namespace FileIt.UserOptions.FindReplace
         public void Init(string path)
         {
         }
+
+        public FlexibleStream CreateStream(string path)
+        {
+            return new FileIOStream(path);
+        }
     }
 }

--- a/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
+++ b/FileIt/UserOptions/FindReplace/FindReplaceInFileName.cs
@@ -1,12 +1,20 @@
 ﻿using System;
 using System.IO;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.FindReplace
 {
     public class FindReplaceInFileName: ISingleFileProcessor
     {
+        private readonly IOsService _osService;
+
+        public FindReplaceInFileName(IOsService osService)
+        {
+            _osService = osService;
+        }
+
         public void Dispose()
         {
         }
@@ -14,11 +22,11 @@ namespace FileIt.UserOptions.FindReplace
         public void Process(FlexibleStream stream, string[] args)
         {
             var argProvider = new ArgumentProvider(args);
-            var fileName = Path.GetFileName(stream.GetFileName());
+            var fileName = _osService.GetFileName(stream.GetFileName());
             var newFileName = fileName.Replace(argProvider.FindWhat, argProvider.ReplaceWith);
-            Console.WriteLine($"{fileName} --> {newFileName}");
+            _osService.WriteLineToConsole($"{fileName} --> {newFileName}");
             var newFilePath = stream.GetFileName().Replace(fileName, newFileName);
-            File.Move(stream.GetFileName(), newFilePath);
+            _osService.MoveFile(stream.GetFileName(), newFilePath);
         }
 
         public void Init(string path)

--- a/FileIt/UserOptions/FindReplace/FindReplaceProcessor.cs
+++ b/FileIt/UserOptions/FindReplace/FindReplaceProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using FileIt.Common;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 
 namespace FileIt.UserOptions.FindReplace
 {
@@ -7,13 +8,13 @@ namespace FileIt.UserOptions.FindReplace
     {
         private readonly ArgumentProvider _argumentProvider;
 
-        public FindReplaceProcessor(string[] args) : base(args)
+        public FindReplaceProcessor(string[] args, IOsService osService) : base(args, osService)
         {
             _argumentProvider = new ArgumentProvider(args);
         }
 
         protected override IArgumentChecker ArgumentChecker => new ArgumentChecker();
-        protected override ISingleFileProcessor SingleFileProcessor => new FindReplaceInFileName();
+        protected override ISingleFileProcessor SingleFileProcessor => new FindReplaceInFileName(OsService);
         protected override FileExtractor FileExtractor => new SimpleFileExtractor(_argumentProvider.Pattern);
     }
 }

--- a/FileIt/UserOptions/FindReplace/FindReplaceProcessor.cs
+++ b/FileIt/UserOptions/FindReplace/FindReplaceProcessor.cs
@@ -15,6 +15,6 @@ namespace FileIt.UserOptions.FindReplace
 
         protected override IArgumentChecker ArgumentChecker => new ArgumentChecker();
         protected override ISingleFileProcessor SingleFileProcessor => new FindReplaceInFileName(OsService);
-        protected override FileExtractor FileExtractor => new SimpleFileExtractor(_argumentProvider.Pattern);
+        protected override FileExtractor FileExtractor => new StandardFileExtractor(_argumentProvider.Pattern);
     }
 }

--- a/FileIt/UserOptions/ReplaceIsNull2/ReplaceIsNullProcessor.cs
+++ b/FileIt/UserOptions/ReplaceIsNull2/ReplaceIsNullProcessor.cs
@@ -1,16 +1,17 @@
 ﻿using FileIt.Common;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 
 namespace FileIt.UserOptions.ReplaceIsNull2
 {
     public class ReplaceIsNullProcessor: SpecificOptionProcessor
     {
-        public ReplaceIsNullProcessor(string[] args) : base(args)
+        public ReplaceIsNullProcessor(string[] args, IOsService osService) : base(args, osService)
         {
         }
 
         protected override IArgumentChecker ArgumentChecker => new SingleArgumentPathChecker();
-        protected override ISingleFileProcessor SingleFileProcessor => new SingleFileReplacer();
+        protected override ISingleFileProcessor SingleFileProcessor => new SingleFileReplacer(OsService);
         protected override FileExtractor FileExtractor => new SimpleFileExtractor("*.cs");
     }
 }

--- a/FileIt/UserOptions/ReplaceIsNull2/ReplaceIsNullProcessor.cs
+++ b/FileIt/UserOptions/ReplaceIsNull2/ReplaceIsNullProcessor.cs
@@ -12,6 +12,6 @@ namespace FileIt.UserOptions.ReplaceIsNull2
 
         protected override IArgumentChecker ArgumentChecker => new SingleArgumentPathChecker();
         protected override ISingleFileProcessor SingleFileProcessor => new SingleFileReplacer(OsService);
-        protected override FileExtractor FileExtractor => new SimpleFileExtractor("*.cs");
+        protected override FileExtractor FileExtractor => new StandardFileExtractor("*.cs");
     }
 }

--- a/FileIt/UserOptions/ReplaceIsNull2/SingleFileReplacer.cs
+++ b/FileIt/UserOptions/ReplaceIsNull2/SingleFileReplacer.cs
@@ -2,15 +2,23 @@
 using System.Collections.Generic;
 using System.IO;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.ReplaceIsNull2
 {
     public class SingleFileReplacer: ISingleFileProcessor
     {
+        private readonly IOsService _osService;
+
+        public SingleFileReplacer(IOsService osService)
+        {
+            _osService = osService;
+        }
+
         public void Process(FlexibleStream stream, string[] args)
         {
-            Console.WriteLine("Input file: {0}", stream.GetFileName());
+            _osService.WriteLineToConsole($"Input file: {stream.GetFileName()}");
             List<string> lines = new List<string>();
             int replacements = 0;
             var rpl = new Replacer();
@@ -28,7 +36,7 @@ namespace FileIt.UserOptions.ReplaceIsNull2
             {
                 stream.WriteLine(line);
             }
-            Console.WriteLine("Replaced IsNull and IsNotNull {0} occurences", replacements);
+            _osService.WriteLineToConsole("Replaced IsNull and IsNotNull {replacements} occurences");
         }
 
         public void Init(string path)

--- a/FileIt/UserOptions/ReplaceIsNull2/SingleFileReplacer.cs
+++ b/FileIt/UserOptions/ReplaceIsNull2/SingleFileReplacer.cs
@@ -22,6 +22,8 @@ namespace FileIt.UserOptions.ReplaceIsNull2
                 replacements += rpl.Replace(line, out replaced);
                 lines.Add(replaced);
             }
+            var underlying_stream = stream.Stream;
+            underlying_stream.Position = 0;
             foreach (var line in lines)
             {
                 stream.WriteLine(line);
@@ -35,6 +37,11 @@ namespace FileIt.UserOptions.ReplaceIsNull2
 
         public void Dispose()
         {
+        }
+
+        public FlexibleStream CreateStream(string path)
+        {
+            return new FileIOStream(path, FileMode.Open, FileAccess.ReadWrite);
         }
     }
 }

--- a/FileIt/UserOptions/ReplaceIsNull2/SingleFileReplacer.cs
+++ b/FileIt/UserOptions/ReplaceIsNull2/SingleFileReplacer.cs
@@ -2,33 +2,29 @@
 using System.Collections.Generic;
 using System.IO;
 using FileIt.Interaces;
+using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.ReplaceIsNull2
 {
     public class SingleFileReplacer: ISingleFileProcessor
     {
-        public void Process(string file, string[] args)
+        public void Process(FlexibleStream stream, string[] args)
         {
-            Console.WriteLine("Input file: {0}", file);
+            Console.WriteLine("Input file: {0}", stream.GetFileName());
             List<string> lines = new List<string>();
             int replacements = 0;
             var rpl = new Replacer();
-            using (StreamReader sr = new StreamReader(file))
+            var sr = stream.GetReader();
+            while (!sr.EndOfStream)
             {
-                while (!sr.EndOfStream)
-                {
-                    var line = sr.ReadLine();
-                    string replaced;
-                    replacements += rpl.Replace(line, out replaced);
-                    lines.Add(replaced);
-                }
+                var line = sr.ReadLine();
+                string replaced;
+                replacements += rpl.Replace(line, out replaced);
+                lines.Add(replaced);
             }
-            using (var sw = new StreamWriter(file, false))
+            foreach (var line in lines)
             {
-                foreach (var line in lines)
-                {
-                    sw.WriteLine(line);
-                }
+                stream.WriteLine(line);
             }
             Console.WriteLine("Replaced IsNull and IsNotNull {0} occurences", replacements);
         }

--- a/FileIt/UserOptions/SqlScriptMerger/FileNameSorter.cs
+++ b/FileIt/UserOptions/SqlScriptMerger/FileNameSorter.cs
@@ -20,12 +20,10 @@ namespace FileIt.UserOptions.SqlScriptMerger
             var filteredFiles = SortOutOutputFile(files);
             if (_sortOrder == null) return filteredFiles;
             var sortOrder = new List<string>();
-            using (var reader = _sortOrder.GetReader())
+            var reader = _sortOrder.GetReader();
+            while (!reader.EndOfStream)
             {
-                while (!reader.EndOfStream)
-                {
-                    sortOrder.Add(reader.ReadLine());
-                }
+                sortOrder.Add(reader.ReadLine());
             }
             var sortedList = filteredFiles.ToList();
             sortedList.Sort(new FileComparer(sortOrder));

--- a/FileIt/UserOptions/SqlScriptMerger/SingleFileMerger.cs
+++ b/FileIt/UserOptions/SqlScriptMerger/SingleFileMerger.cs
@@ -29,5 +29,10 @@ namespace FileIt.UserOptions.SqlScriptMerger
         {
             _outputStream?.Dispose();
         }
+
+        public FlexibleStream CreateStream(string path)
+        {
+            return new FileIOStream(path);
+        }
     }
 }

--- a/FileIt/UserOptions/SqlScriptMerger/SingleFileMerger.cs
+++ b/FileIt/UserOptions/SqlScriptMerger/SingleFileMerger.cs
@@ -18,14 +18,11 @@ namespace FileIt.UserOptions.SqlScriptMerger
             _fileMerger = new FileMerger(_outputStream);
         }
 
-        public void Process(string file, string[] args)
+        public void Process(FlexibleStream stream, string[] args)
         {
-            var fileName = Path.GetFileName(file);
+            var fileName = Path.GetFileName(stream.GetFileName());
             Console.WriteLine(fileName);
-            using (var stream = new FileIOStream(file))
-            {
-                _fileMerger.Append(stream);
-            }
+            _fileMerger.Append(stream);
         }
 
         public void Dispose()

--- a/FileIt/UserOptions/SqlScriptMerger/SingleFileMerger.cs
+++ b/FileIt/UserOptions/SqlScriptMerger/SingleFileMerger.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 using FlexibleStreamHandling;
 
 namespace FileIt.UserOptions.SqlScriptMerger
@@ -9,19 +10,25 @@ namespace FileIt.UserOptions.SqlScriptMerger
     {
         private FileIOStream _outputStream;
         private FileMerger _fileMerger;
+        private readonly IOsService _osService;
+
+        public SingleFileMerger(IOsService osService)
+        {
+            _osService = osService;
+        }
 
         public void Init(string path)
         {
             var outputPath = Path.Combine(path, Constants.OutputFilename);
-            Console.WriteLine($"Writing aggregated sql script to \n{outputPath}");
+            _osService.WriteLineToConsole($"Writing aggregated sql script to \n{outputPath}");
             _outputStream = new FileIOStream(outputPath, FileMode.Create, FileAccess.Write);
             _fileMerger = new FileMerger(_outputStream);
         }
 
         public void Process(FlexibleStream stream, string[] args)
         {
-            var fileName = Path.GetFileName(stream.GetFileName());
-            Console.WriteLine(fileName);
+            var fileName = _osService.GetFileName(stream.GetFileName());
+            _osService.WriteLineToConsole(fileName);
             _fileMerger.Append(stream);
         }
 

--- a/FileIt/UserOptions/SqlScriptMerger/SqlScriptFileExtractor.cs
+++ b/FileIt/UserOptions/SqlScriptMerger/SqlScriptFileExtractor.cs
@@ -16,13 +16,13 @@ namespace FileIt.UserOptions.SqlScriptMerger
 
         public override string[] ExtractFiles(string path)
         {
-            var sortFileFinder = new SimpleFileExtractor(Constants.FileExecuteOrderFileName);
+            var sortFileFinder = new StandardFileExtractor(Constants.FileExecuteOrderFileName);
             var sortFilePath = sortFileFinder.ExtractFiles(path).
                 ToList().FirstOrDefault();
             Console.WriteLine(sortFilePath != null ? $"Sort file found ({sortFilePath})" : "No sort file found");
             _sortFileStream = sortFilePath != null ? new FileIOStream(sortFilePath) : null;
             var sorter = new FileNameSorter(_sortFileStream, Constants.OutputFilename);
-            var extractor = new SimpleFileExtractor(Pattern);
+            var extractor = new StandardFileExtractor(Pattern);
             var files = extractor.ExtractFiles(path);
             return sorter.SortFiles(files);
         }

--- a/FileIt/UserOptions/SqlScriptMerger/SqlScriptMergerProcessor.cs
+++ b/FileIt/UserOptions/SqlScriptMerger/SqlScriptMergerProcessor.cs
@@ -1,16 +1,17 @@
 ﻿using FileIt.Common;
 using FileIt.Interaces;
+using FileIt.Interfaces;
 
 namespace FileIt.UserOptions.SqlScriptMerger
 {
     public class SqlScriptMergerProcessor: SpecificOptionProcessor
     {
-        public SqlScriptMergerProcessor(string[] args) : base(args)
+        public SqlScriptMergerProcessor(string[] args, IOsService osService) : base(args, osService)
         {
         }
 
         protected override IArgumentChecker ArgumentChecker => new SingleArgumentPathChecker();
-        protected override ISingleFileProcessor SingleFileProcessor => new SingleFileMerger();
+        protected override ISingleFileProcessor SingleFileProcessor => new SingleFileMerger(OsService);
         protected override FileExtractor FileExtractor => new SqlScriptFileExtractor("*.sql");
     }
 }

--- a/UnitTests/FindReplace/SingleFileTests.cs
+++ b/UnitTests/FindReplace/SingleFileTests.cs
@@ -1,0 +1,100 @@
+﻿using FileIt.UserOptions.FindReplace;
+using FlexibleStreamHandling;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using UnitTests.Utility;
+
+namespace UnitTests.FindReplace
+{
+    [TestFixture]
+    class SingleFileTests
+    {
+        [Test]
+        public void FindReplaceInFileNames_FileMatchFindStr_FileNameChanged()
+        {
+            //Arrange
+            var filepath = @"c:\tmp\afilename_mmm.txt";
+            var findstr = "mmm";
+            string[] args = {"findreplace", ".", "*.txt", findstr};
+            var osService = new TestOsService();
+            var nameProcessor = new FindReplaceInFileName(osService);
+
+            //Act
+            using (var stream = new StringReader("", filepath))
+            {
+                nameProcessor.Process(stream, args);
+            }
+
+            //Assert
+            Assert.AreEqual(osService.ChangedFiles.Count, 1);
+            Assert.AreEqual(filepath, osService.ChangedFiles[0].Item1);
+            Assert.AreEqual(@"c:\tmp\afilename_.txt", osService.ChangedFiles[0].Item2);
+        }
+        [Test]
+        public void FindReplaceInFileNames_CaseMismatch_FilenameChanged()
+        {
+            //Arrange
+            var filepath = @"c:\tmp\afilename_mmm.txt";
+            var findstr = "mMm";
+            string[] args = { "findreplace", ".", "*.txt", findstr };
+            var osService = new TestOsService();
+            var nameProcessor = new FindReplaceInFileName(osService);
+
+            //Act
+            using (var stream = new StringReader("", filepath))
+            {
+                nameProcessor.Process(stream, args);
+            }
+
+            //Assert
+            Assert.AreEqual(osService.ChangedFiles.Count, 1);
+            Assert.AreEqual(filepath, osService.ChangedFiles[0].Item1);
+            Assert.AreEqual(@"c:\tmp\afilename_.txt", osService.ChangedFiles[0].Item2);
+
+        }
+
+        [Test]
+        public void FindReplaceInFileNames_ReplacementTextNotNull_FilenameChanged()
+        {
+            //Arrange
+            var filepath = @"c:\tmp\afilename_mmm.txt";
+            var findstr = "mMm";
+            var replacestr = "X";
+            string[] args = { "findreplace", ".", "*.txt", findstr, replacestr };
+            var osService = new TestOsService();
+            var nameProcessor = new FindReplaceInFileName(osService);
+
+            //Act
+            using (var stream = new StringReader("", filepath))
+            {
+                nameProcessor.Process(stream, args);
+            }
+
+            //Assert
+            Assert.AreEqual(osService.ChangedFiles.Count, 1);
+            Assert.AreEqual(filepath, osService.ChangedFiles[0].Item1);
+            Assert.AreEqual(@"c:\tmp\afilename_X.txt", osService.ChangedFiles[0].Item2);
+
+        }
+
+        [Test]
+        public void FindReplaceInFileNames_FileDoNotMatch_FileNotChanged()
+        {
+            //Arrange
+            var filepath = @"c:\tmp\anotherfile.txt";
+            var findstr = "mMm";
+            string[] args = { "findreplace", ".", "*.txt", findstr };
+            var osService = new TestOsService();
+            var nameProcessor = new FindReplaceInFileName(osService);
+
+            //Act
+            using (var stream = new StringReader("", filepath))
+            {
+                nameProcessor.Process(stream, args);
+            }
+
+            //Assert
+            Assert.AreEqual(0, osService.ChangedFiles.Count);
+        }
+    }
+}

--- a/UnitTests/LoopFilesTests.cs
+++ b/UnitTests/LoopFilesTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests
         public void TestLoopFilesByDir()
         {
             var path = @"C:\Smajobb\Misc\Test code\ReplaceIsNull\ReplaceIsNull";
-            var iter = new SimpleFileExtractor("*.cs");
+            var iter = new StandardFileExtractor("*.cs");
             var files = iter.ExtractFiles(path);
             Assert.AreEqual(10, files.Length);
         }
@@ -21,7 +21,7 @@ namespace UnitTests
         public void TestIsDirectory()
         {
             var path = @"C:\Smajobb\Misc\Test code\ReplaceIsNull\ReplaceIsNull";
-            var iter = new SimpleFileExtractor("");
+            var iter = new StandardFileExtractor("");
             Assert.IsTrue(iter.IsDirectory(path)); 
         }
 
@@ -29,7 +29,7 @@ namespace UnitTests
         public void TestIsFile()
         {
             var path = @"C:\Smajobb\Misc\Test code\ReplaceIsNull\ReplaceIsNull\ReplaceIsNull.csproj";
-            var iter = new SimpleFileExtractor("");
+            var iter = new StandardFileExtractor("");
             Assert.IsFalse(iter.IsDirectory(path));
 
         }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ReplaceIsNullTests.cs" />
     <Compile Include="SqlScriptMerger\FileSorterTests.cs" />
     <Compile Include="SqlScriptMerger\MergeSqlScriptTests.cs" />
+    <Compile Include="Utility\TestOsService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgumentCheckTests.cs" />
+    <Compile Include="FindReplace\SingleFileTests.cs" />
     <Compile Include="LoopFilesTests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -70,9 +71,7 @@
       <Name>FileIt</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="FindReplace\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UnitTests/Utility/TestOsService.cs
+++ b/UnitTests/Utility/TestOsService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using FileIt.Interfaces;
+
+namespace UnitTests.Utility
+{
+    class TestOsService: IOsService
+    {
+        public string GetFileName(string path)
+        {
+            string[] sep = {@"/", @"\"};
+            var split = path.Split(sep, StringSplitOptions.None);
+            return split.ToList().LastOrDefault(x => true);
+        }
+
+        public void WriteLineToConsole(string str)
+        {
+        }
+
+        public void MoveFile(string sourceFileName, string destFileName)
+        {
+        }
+    }
+}

--- a/UnitTests/Utility/TestOsService.cs
+++ b/UnitTests/Utility/TestOsService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FileIt.Interfaces;
 
@@ -6,6 +7,13 @@ namespace UnitTests.Utility
 {
     class TestOsService: IOsService
     {
+        public List<Tuple<string, string>> ChangedFiles { get; }
+
+        public TestOsService()
+        {
+            ChangedFiles = new List<Tuple<string, string>>();
+        }
+
         public string GetFileName(string path)
         {
             string[] sep = {@"/", @"\"};
@@ -19,6 +27,7 @@ namespace UnitTests.Utility
 
         public void MoveFile(string sourceFileName, string destFileName)
         {
+            ChangedFiles.Add(new Tuple<string, string>(sourceFileName, destFileName));
         }
     }
 }


### PR DESCRIPTION
Replace in-argument file from string (the file name) to a flexible stream. Also, make classes for OsService. In production code, OsService make commands to the operating system, such as File.Move, etc. 

Some operating system commands is not yet moved to OsService. The goal was to make the find and replace option testable. 