### PR TITLE
Fix stream to both read and write within same method

### DIFF
--- a/FileIt/Program.cs
+++ b/FileIt/Program.cs
@@ -65,7 +65,7 @@ namespace FileIt
                 case "changecodepage":
                     str = @"ChangeCodePage <path>
 
-Recursively changes code page for all .sql files under
+Recursively changes encoding to code page 1252 (latin1) for all .sql files under
 the specified path.
 Use '.' for current path. ";
                     break;

--- a/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
+++ b/FileIt/UserOptions/ChangeCodePage/SingleFileConverter.cs
@@ -27,6 +27,8 @@ namespace FileIt.UserOptions.ChangeCodePage
                 var line = sr.ReadLine();
                 lines.Add(line);
             }
+
+            stream.ReOpenAs(FileMode.Create, FileAccess.Write);
             foreach (var line in lines)
             {
                 stream.WriteLine(line);

--- a/UnitTests/FindReplace/SingleFileTests.cs
+++ b/UnitTests/FindReplace/SingleFileTests.cs
@@ -14,43 +14,43 @@ namespace UnitTests.FindReplace
         public void FindReplaceInFileNames_FileMatchFindStr_FileNameChanged()
         {
             //Arrange
-            var filepath = @"c:\tmp\afilename_mmm.txt";
+            var fileName = @"afilename_mmm.txt";
             var findstr = "mmm";
             string[] args = {"findreplace", ".", "*.txt", findstr};
             var osService = new TestOsService();
             var nameProcessor = new FindReplaceInFileName(osService);
 
             //Act
-            using (var stream = new StringReader("", filepath))
+            using (var stream = new StringReader("", fileName))
             {
                 nameProcessor.Process(stream, args);
             }
 
             //Assert
             Assert.AreEqual(osService.ChangedFiles.Count, 1);
-            Assert.AreEqual(filepath, osService.ChangedFiles[0].Item1);
-            Assert.AreEqual(@"c:\tmp\afilename_.txt", osService.ChangedFiles[0].Item2);
+            Assert.AreEqual($@"c:\{fileName}", osService.ChangedFiles[0].Item1);
+            Assert.AreEqual(@"c:\afilename_.txt", osService.ChangedFiles[0].Item2);
         }
         [Test]
         public void FindReplaceInFileNames_CaseMismatch_FilenameChanged()
         {
             //Arrange
-            var filepath = @"c:\tmp\afilename_mmm.txt";
+            var fileName = @"afilename_mmm.txt";
             var findstr = "mMm";
             string[] args = { "findreplace", ".", "*.txt", findstr };
             var osService = new TestOsService();
             var nameProcessor = new FindReplaceInFileName(osService);
 
             //Act
-            using (var stream = new StringReader("", filepath))
+            using (var stream = new StringReader("", fileName))
             {
                 nameProcessor.Process(stream, args);
             }
 
             //Assert
             Assert.AreEqual(osService.ChangedFiles.Count, 1);
-            Assert.AreEqual(filepath, osService.ChangedFiles[0].Item1);
-            Assert.AreEqual(@"c:\tmp\afilename_.txt", osService.ChangedFiles[0].Item2);
+            Assert.AreEqual($@"c:\{fileName}", osService.ChangedFiles[0].Item1);
+            Assert.AreEqual(@"c:\afilename_.txt", osService.ChangedFiles[0].Item2);
 
         }
 
@@ -58,7 +58,7 @@ namespace UnitTests.FindReplace
         public void FindReplaceInFileNames_ReplacementTextNotNull_FilenameChanged()
         {
             //Arrange
-            var filepath = @"c:\tmp\afilename_mmm.txt";
+            var fileName = @"afilename_mmm.txt";
             var findstr = "mMm";
             var replacestr = "X";
             string[] args = { "findreplace", ".", "*.txt", findstr, replacestr };
@@ -66,15 +66,15 @@ namespace UnitTests.FindReplace
             var nameProcessor = new FindReplaceInFileName(osService);
 
             //Act
-            using (var stream = new StringReader("", filepath))
+            using (var stream = new StringReader("", fileName))
             {
                 nameProcessor.Process(stream, args);
             }
 
             //Assert
             Assert.AreEqual(osService.ChangedFiles.Count, 1);
-            Assert.AreEqual(filepath, osService.ChangedFiles[0].Item1);
-            Assert.AreEqual(@"c:\tmp\afilename_X.txt", osService.ChangedFiles[0].Item2);
+            Assert.AreEqual($@"c:\{fileName}", osService.ChangedFiles[0].Item1);
+            Assert.AreEqual(@"c:\afilename_X.txt", osService.ChangedFiles[0].Item2);
 
         }
 


### PR DESCRIPTION
The flexible stream has to be reopened with write permissions after the contents of the file have been read inte local variable. Call stream.ReOpenAs(...)